### PR TITLE
Really Deterministic K Generating

### DIFF
--- a/app/src/main/java/io/plactal/eoscommander/crypto/ec/EcDsa.java
+++ b/app/src/main/java/io/plactal/eoscommander/crypto/ec/EcDsa.java
@@ -77,7 +77,7 @@ public class EcDsa {
 
     private static BigInteger deterministicGenerateK(CurveParam curveParam, byte[] hash, BigInteger d, SigChecker checker, int nonce ){
         if ( nonce > 0 ){
-            hash = Sha256.from(hash, EosPrivateKey.getSecuRandom().generateSeed(nonce)).getBytes();
+            hash = Sha256.from(hash, BigInteger.valueOf(nonce).toByteArray()).getBytes();
         }
 
         byte[] dBytes = d.toByteArray();


### PR DESCRIPTION
Random number seeded from nonce combined with the message hash will result in a nondeterministic K value. Nondeterministic K values may cause users' private key exposes.

Even when it's from secure random, this K value does not comply with [RFC6979](https://tools.ietf.org/html/rfc6979).

Since the method name is called `deterministicGenerateK`, I think you know you want to get a deterministic output with the same inputs given. Somehow you let the secure random part slip in. I removed that part for you. Only the increasing nonce will be enough to help you find the right K.

With more CAUTION should code be dealt when it's crypto currencies related.